### PR TITLE
feat: 모달 공통 컴포넌트 

### DIFF
--- a/src/app/routes/routes.tsx
+++ b/src/app/routes/routes.tsx
@@ -8,6 +8,7 @@ import { MyPage } from '@/pages/MyPage';
 import { SharePage } from '@/pages/SharePage';
 import { SignupPage } from '@/pages/SignupPage';
 import { TeamPage } from '@/pages/TeamPage';
+import { ModalTestPage } from '@/pages/test/modal';
 import { TodoPage } from '@/pages/TodoPage';
 import { Route, Routes } from 'react-router-dom';
 
@@ -21,28 +22,23 @@ export default function AppRoutes() {
         <Route path="/signup" element={<SignupPage />} />
         {/* Team Page */}
         <Route path="/team" element={<TeamPage />} />
-
         {/* Main page */}
         <Route path="/" element={<MainPage />} />
-
         {/* Calendar Page */}
         <Route path="/calendar" element={<CalendarPage />} />
-
         {/* Todo Page */}
         <Route path="/todo" element={<TodoPage />} />
-
         {/* Memo Page */}
         <Route path="/memo" element={<MemoPage />} />
-
         {/* Share Page */}
         <Route path="/share" element={<SharePage />} />
-
         {/* Management Page */}
         <Route path="/management" element={<ManagementPage />} />
-
         {/* My Page */}
         <Route path="/mypage" element={<MyPage />} />
 
+        {/* Modal Test Page */}
+        <Route path="/test/modal" element={<ModalTestPage />} />
         {/* Error Page */}
         <Route path="*" element={<ErrorPage />} />
       </Routes>

--- a/src/pages/test/modal.tsx
+++ b/src/pages/test/modal.tsx
@@ -12,6 +12,7 @@ export function ModalTestPage() {
       <Modal isOpen={isOpen} toggle={toggle}>
         <ModalWrapper>
           <p>hi</p>
+          <ClosedBtn onClick={toggle}>close</ClosedBtn>
         </ModalWrapper>
       </Modal>
     </div>
@@ -19,6 +20,13 @@ export function ModalTestPage() {
 }
 
 const ModalWrapper = styled.div`
+  position: relative;
   width: 552px;
   height: 168px;
+`;
+
+const ClosedBtn = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
 `;

--- a/src/pages/test/modal.tsx
+++ b/src/pages/test/modal.tsx
@@ -1,0 +1,24 @@
+import Modal from '@/shared/components/modal/Modal';
+import useToggle from '@/shared/hooks/useToggle';
+import styled from 'styled-components';
+
+export function ModalTestPage() {
+  const { isOpen, toggle } = useToggle();
+
+  return (
+    <div>
+      <button onClick={toggle}>Modal Open</button>
+
+      <Modal isOpen={isOpen} toggle={toggle}>
+        <ModalWrapper>
+          <p>hi</p>
+        </ModalWrapper>
+      </Modal>
+    </div>
+  );
+}
+
+const ModalWrapper = styled.div`
+  width: 552px;
+  height: 168px;
+`;

--- a/src/shared/components/modal/Modal.tsx
+++ b/src/shared/components/modal/Modal.tsx
@@ -1,0 +1,95 @@
+import { ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import styled, { keyframes } from 'styled-components';
+
+interface ModalProps {
+  children: ReactNode;
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+export default function Modal({ children, isOpen, toggle }: ModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.showModal();
+      dialogRef.current?.scrollTo({
+        top: 0,
+      });
+    } else {
+      const timer = setTimeout(() => {
+        dialogRef.current?.close();
+      }, 200); // 애니메이션 시간과 동일하게 설정
+
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  return createPortal(
+    <Dialog
+      $isOpen={isOpen}
+      onClick={(e) => {
+        // 모달 바깥을 클릭하면 닫히도록
+        if ((e.target as any).nodeName === 'DIALOG') {
+          toggle();
+        }
+      }}
+      ref={dialogRef}
+    >
+      {children}
+    </Dialog>,
+    document.body, // 모달을 body에 렌더링
+  );
+}
+
+const fadeIn = keyframes`
+  0% {
+    transform: scale(0.9) translate(-55%, -60%);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1) translate(-50%, -50%);
+    opacity: 1;
+  }
+`;
+
+const fadeOut = keyframes`
+  0% {
+    transform: scale(1) translate(-50%, -50%);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.9) translate(-55%, -60%);
+    opacity: 0;
+  }
+`;
+
+const showBackdrop = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
+const Dialog = styled.dialog<{ $isOpen: boolean }>`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 300px;
+  padding: 0;
+  border: none;
+  background-color: ${({ theme }) => theme.colors.white};
+  animation: ${({ $isOpen }) => ($isOpen ? fadeIn : fadeOut)} 0.4s ease;
+
+  &[open]::backdrop {
+    animation: ${showBackdrop} 0.4s ease;
+  }
+
+  &::backdrop {
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+`;

--- a/src/shared/components/modal/Modal.tsx
+++ b/src/shared/components/modal/Modal.tsx
@@ -1,16 +1,20 @@
-import { ReactNode, useEffect, useRef } from 'react';
+import { IModal } from '@/shared/types/modal.types';
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import styled, { keyframes } from 'styled-components';
 
-interface ModalProps {
-  children: ReactNode;
-  isOpen: boolean;
-  toggle: () => void;
-}
+/**
+ * Modal 컴포넌트는 모달을 렌더링합니다.
+ *
+ * @param {boolean} isOpen - 모달이 열려 있는지 여부를 나타내는 상태
+ * @param {() => void} toggle - 모달의 열림/닫힘 상태를 토글하는 훅
+ * @param {ReactNode} children - 모달의 내용
+ */
 
-export default function Modal({ children, isOpen, toggle }: ModalProps) {
+export default function Modal({ children, isOpen, toggle }: IModal) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
+  // 모달 열고 닫는 기본 로직
   useEffect(() => {
     if (isOpen) {
       dialogRef.current?.showModal();
@@ -20,7 +24,7 @@ export default function Modal({ children, isOpen, toggle }: ModalProps) {
     } else {
       const timer = setTimeout(() => {
         dialogRef.current?.close();
-      }, 200); // 애니메이션 시간과 동일하게 설정
+      }, 200); // 애니메이션 시간보다 조금 더 빠르게
 
       return () => clearTimeout(timer);
     }

--- a/src/shared/hooks/useToggle.ts
+++ b/src/shared/hooks/useToggle.ts
@@ -1,0 +1,13 @@
+import { useCallback, useState } from 'react';
+
+const useToggle = (initialState = false) => {
+  const [isOpen, setIsOpen] = useState<boolean>(initialState);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  return { isOpen, setIsOpen, toggle };
+};
+
+export default useToggle;

--- a/src/shared/types/modal.types.ts
+++ b/src/shared/types/modal.types.ts
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+interface IModal {
+  children: ReactNode;
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+export type { IModal };


### PR DESCRIPTION
### 작업 내용 요약
모달 공통 컴포넌트 구현

모달을 공통 컴포넌트로 분리하여 재사용할 수 있도록 구현했습니다.
해당 컴포넌트는 외부 영역 클릭 및 닫기 버튼을 통한 모달 닫기 기능을 포함하고 있습니다.


https://github.com/user-attachments/assets/cafbe67d-85b4-4ae5-8bb2-1537cb23b824

<br>

### 사용 방법

**코드 예시**

```ts
import Modal from '@/shared/components/modal/Modal';
import useToggle from '@/shared/hooks/useToggle';
import styled from 'styled-components';

export function ModalTestPage() {
  const { isOpen, toggle } = useToggle();

  return (
    <div>
      <button onClick={toggle}>Modal Open</button>

      <Modal isOpen={isOpen} toggle={toggle}>
        <ModalWrapper>
          <p>hi</p>
          <ClosedBtn onClick={toggle}>close</ClosedBtn>
        </ModalWrapper>
      </Modal>
    </div>
  );
}

const ModalWrapper = styled.div`
  position: relative;
  width: 552px;
  height: 168px;
`;

const ClosedBtn = styled.button`
  position: absolute;
  top: 10px;
  right: 10px;
`;

```

### 1. `Modal`을 import 해온다
`Modal` 컴포넌트 내부에는 크게 두가지 기능을 로직으로 구현해두었습니다.
(자세한 로직은 코드 내 주석 참고 바랍니다)

- 바깥 클릭 시 모달 닫기 기능
- 닫기 버튼 클릭 시 모달 닫기 기능

열고 닫히는 로직은 `useToggle` 훅을 통해 구현해두었으니 import 해주셔야 합니다.

<br>

### 2. `Modal` 컴포넌트에 `isOpen`과 `toggle` 상태를 내려준다

<br>

### 3. `Modal` 컴포넌트의 자식 요소로 컨테이너를 하나 생성 (ex. `ModalWrapper`)하여 자유롭게 커스텀 스타일링한다.

<br>

### 4. 닫기 버튼이나, 특정 버튼을 눌러서 닫고 싶을 때는 

```ts
          <ClosedBtn onClick={toggle}>close</ClosedBtn>
```
버튼을 생성하여 `onClick` 속성에 `toggle`을 내려준다



<br>

---

### 공유할 사항
공통 컴포넌트는 지라에서 따로 `공통 컴포넌트` 에픽 이슈를 만들어서 작업했으니 참고해주세요!

