### PR TITLE
[TM-140] 역할태그 공통 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
     "typescript-eslint": "^8.15.0",
     "vite": "^6.0.1",
     "vite-plugin-svgr": "^4.3.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/entities/resource/ui/ResourceCard.tsx
+++ b/src/entities/resource/ui/ResourceCard.tsx
@@ -38,7 +38,7 @@ export default function ResourceCard({
 
       <TagAndDeleteWrapper>
         {/* 업로드 한 사람 이름으로 수정 예정 */}
-        <RoleTag>김예안</RoleTag>
+        <RoleTag height={28}>김예안</RoleTag>
         {deleteButton}
       </TagAndDeleteWrapper>
     </Container>

--- a/src/features/calendar/ui/EventEditorModal.tsx
+++ b/src/features/calendar/ui/EventEditorModal.tsx
@@ -35,7 +35,7 @@ function EventEditorModal({ date }: { date: Date }) {
     <Modal isOpen={isModalOpen} toggle={toggleModal}>
       <ModalWrapper>
         <DeleteIconWrapper onClick={toggleModal}>
-          <DeleteIcon stroke="#5A5A5A" />
+          <DeleteIcon stroke="#5A5A5A" strokeWidth={2} />
         </DeleteIconWrapper>
 
         {/* 날짜 */}

--- a/src/features/resource/ui/DeleteResourceButton.tsx
+++ b/src/features/resource/ui/DeleteResourceButton.tsx
@@ -21,7 +21,7 @@ export default function DeleteResourceButton({
 
   return (
     <ButtonContainer {...props} onClick={handleDeleteClick}>
-      <DeleteIcon width="16px" height="16px" stroke="#5a5a5a" />
+      <DeleteIcon width="16px" height="16px" stroke="#5a5a5a" strokeWidth={2} />
     </ButtonContainer>
   );
 }

--- a/src/shared/assets/common/delete.svg
+++ b/src/shared/assets/common/delete.svg
@@ -1,7 +1,7 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_4895_4797)">
-<path d="M5.71094 5.71021L18.6086 18.6078" stroke="current" stroke-width="2" stroke-linecap="round"/>
-<path d="M5.71082 18.6089L18.6084 5.71126" stroke="current" stroke-width="2" stroke-linecap="round"/>
+<path d="M5.71094 5.71021L18.6086 18.6078" stroke="current" stroke-width="current" stroke-linecap="round"/>
+<path d="M5.71082 18.6089L18.6084 5.71126" stroke="current" stroke-width="current" stroke-linecap="round"/>
 </g>
 <defs>
 <clipPath id="clip0_4895_4797">

--- a/src/shared/components/tag/RoleTag.tsx
+++ b/src/shared/components/tag/RoleTag.tsx
@@ -1,6 +1,12 @@
 import { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import DeleteIcon from '@/shared/assets/common/delete.svg?react';
+import {
+  ICON_MAX_SIZE,
+  ICON_MIN_SIZE,
+  TAG_MAX_HEIGHT,
+} from './roletag.constants';
+import { Theme } from '@/app/styles/theme';
 
 interface IRoleTagProps {
   variants?: 'filled' | 'ghost';
@@ -37,9 +43,9 @@ export default function RoleTag({
       {onDelete && (
         <DeleteButton onClick={onDelete}>
           <DeleteIcon
-            width={height >= 36 ? 24 : 20}
-            height={height >= 36 ? 24 : 20}
-            stroke={'#5C9EFF'}
+            width={height >= TAG_MAX_HEIGHT ? ICON_MAX_SIZE : ICON_MIN_SIZE}
+            height={height >= TAG_MAX_HEIGHT ? ICON_MAX_SIZE : ICON_MIN_SIZE}
+            stroke={Theme.colors.mainBlue}
             strokeWidth={1}
           />
         </DeleteButton>
@@ -57,10 +63,10 @@ const Container = styled.div<{
   justify-content: center;
   gap: 4px;
   height: ${({ $height }) => `${$height}px`};
-  padding: 0 ${({ $height }) => ($height >= 36 ? '12px' : '8px')};
+  padding: 0 ${({ $height }) => ($height >= TAG_MAX_HEIGHT ? '12px' : '8px')};
   border-radius: 3px;
 
-  font-size: ${({ $height }) => ($height >= 36 ? '14px' : '12px')};
+  font-size: ${({ $height }) => ($height >= TAG_MAX_HEIGHT ? '14px' : '12px')};
   color: ${({ theme }) => theme.colors.mainBlue};
   background-color: ${({ theme, $variants }) =>
     $variants === 'filled' ? theme.colors.background : theme.colors.white};

--- a/src/shared/components/tag/RoleTag.tsx
+++ b/src/shared/components/tag/RoleTag.tsx
@@ -1,38 +1,73 @@
 import { PropsWithChildren } from 'react';
 import styled from 'styled-components';
+import DeleteIcon from '@/shared/assets/common/delete.svg?react';
 
 interface IRoleTagProps {
   variants?: 'filled' | 'ghost';
+  height?: number;
+  onDelete?: () => void;
 }
 
 /**
- * 역할 태그 공통 컴포넌트입니다.
+ * 역할을 나타내는 태그 컴포넌트입니다.
  *
- * @param {'filled' | 'ghost'} [props.variants='filled'] - 태그 스타일을 결정하는 옵션입니다.
+ * @param {'filled' | 'ghost'} [variants='filled'] - 태그 스타일을 결정하는 옵션입니다.
  *   - `filled`: 블루 배경 태그
  *   - `ghost`: 흰 배경 태그
- * @param {React.ReactNode} props.children - 태그 내부에 표시될 내용입니다.
+ * @param {number} [height=28] - 태그의 높이를 결정합니다. 높이에 따라 폰트 크기와 패딩이 조절됩니다.
+ * @param {() => void} [onDelete] - 삭제 버튼 클릭 시 실행될 콜백 함수입니다. **이 prop을 전달하면 태그 오른쪽에 삭제 버튼이 렌더링됩니다.**
+ * @param {React.ReactNode} children - 태그 내부에 표시될 내용입니다.
  *
  * @example
- * <Tag variants="filled">기획자</Tag>
- * <Tag variants="ghost">프론트엔드</Tag>
+ * <RoleTag variants="filled" height={36} onDelete={() => alert('태그 삭제!')}>기획자</RoleTag>
  */
 
 export default function RoleTag({
   variants = 'filled',
+  height = 28,
+  onDelete,
   children,
 }: PropsWithChildren<IRoleTagProps>) {
-  return <Container $variants={variants}>{children}</Container>;
+  return (
+    <Container $variants={variants} $height={height}>
+      {/* 태그 내용 */}
+      {children}
+
+      {/* 태그 삭제 버튼 */}
+      {onDelete && (
+        <DeleteButton $height={height} onClick={onDelete}>
+          <DeleteIcon
+            width={height >= 36 ? 24 : 20}
+            height={height >= 36 ? 24 : 20}
+            stroke={'#5C9EFF'}
+            strokeWidth={1}
+          />
+        </DeleteButton>
+      )}
+    </Container>
+  );
 }
 
-const Container = styled.span<{
+const Container = styled.div<{
   $variants: 'filled' | 'ghost';
+  $height: number;
 }>`
-  padding: 5px 8px;
-  font-size: 12px;
-  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: ${({ $height }) => `${$height}px`};
+  padding: 0 ${({ $height }) => ($height >= 36 ? '12px' : '8px')};
   border-radius: 3px;
+
+  font-size: ${({ $height }) => ($height >= 36 ? '14px' : '12px')};
   color: ${({ theme }) => theme.colors.mainBlue};
   background-color: ${({ theme, $variants }) =>
     $variants === 'filled' ? theme.colors.background : theme.colors.white};
+`;
+
+const DeleteButton = styled.button<{ $height: number }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;

--- a/src/shared/components/tag/RoleTag.tsx
+++ b/src/shared/components/tag/RoleTag.tsx
@@ -35,7 +35,7 @@ export default function RoleTag({
 
       {/* 태그 삭제 버튼 */}
       {onDelete && (
-        <DeleteButton $height={height} onClick={onDelete}>
+        <DeleteButton onClick={onDelete}>
           <DeleteIcon
             width={height >= 36 ? 24 : 20}
             height={height >= 36 ? 24 : 20}
@@ -66,7 +66,7 @@ const Container = styled.div<{
     $variants === 'filled' ? theme.colors.background : theme.colors.white};
 `;
 
-const DeleteButton = styled.button<{ $height: number }>`
+const DeleteButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/shared/components/tag/roletag.constants.ts
+++ b/src/shared/components/tag/roletag.constants.ts
@@ -1,0 +1,6 @@
+const TAG_MAX_HEIGHT = 36;
+
+const ICON_MAX_SIZE = 24;
+const ICON_MIN_SIZE = 20;
+
+export { TAG_MAX_HEIGHT, ICON_MAX_SIZE, ICON_MIN_SIZE };


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Jira 이슈 번호

- TM-140

## 📝 작업 내용

> 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능)

- 구현 기능 요약

  - 역할태그 공통 컴포넌트 구현

- 주요 변경사항
  - height 값에 따라 폰트 사이즈, 패딩값 조절 기능 추가
  - 태그 삭제 버튼 조건부 렌더링 및 삭제 버튼 클릭 시 실행될 이벤트 핸들러 추가

## 💬 기타

- 리뷰어가 알아야 할 사항

<img width="279" height="169" alt="스크린샷 2025-08-20 오후 1 56 53" src="https://github.com/user-attachments/assets/aa0d093f-ccfa-479f-89e0-68a9172987ee" />
<img width="831" height="236" alt="스크린샷 2025-08-20 오후 1 57 08" src="https://github.com/user-attachments/assets/8150b52e-fd08-4f66-87c5-0dc15a055f07" />
<img width="717" height="401" alt="스크린샷 2025-08-20 오후 1 57 30" src="https://github.com/user-attachments/assets/09294414-ee62-494b-9622-641b050a7601" />

거의 모든 페이지에서 사용되는 역할 태그를 공통 컴포넌트로 구현하였습니다.
관련 내용은 `RoleTag` 파일 내부에 주석으로 자세히 기재해두었으니 확인부탁드립니다!