### PR TITLE
[TM-148] 팀 정보 동적 로드

### DIFF
--- a/src/entities/end/model/useEndMutations.ts
+++ b/src/entities/end/model/useEndMutations.ts
@@ -1,22 +1,23 @@
 import { useMutation } from '@tanstack/react-query';
 import { queryClient } from '@/app/provider/queryClient';
 import apiRequest from '@/shared/api/apiRequest.ts';
-
-export const TEAM_ID = 3;
+import { useTeamStore } from '@/shared/model/store/teamStore.ts';
 
 export default function useEndMutations() {
+  const teamId = useTeamStore((state) => state.teamId);
+
   // 팀 제거 (팀 나가기) - 팀원
   const useWithdrawTeamMutation = () => {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async () => {
         return await apiRequest({
-          url: `/api/v2/team/${TEAM_ID}/withdrawal`,
+          url: `/api/v2/team/${teamId}/withdrawal`,
           method: 'DELETE',
         });
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['end', 'team', TEAM_ID],
+          queryKey: ['end', 'team', teamId],
         });
       },
     });
@@ -28,13 +29,13 @@ export default function useEndMutations() {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async () => {
         return await apiRequest({
-          url: `/api/v2/team/${TEAM_ID}/complete`,
+          url: `/api/v2/team/${teamId}/complete`,
           method: 'PATCH',
         });
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['end', 'team', TEAM_ID],
+          queryKey: ['end', 'team', teamId],
         });
       },
     });

--- a/src/entities/management/model/useTeamMutations.ts
+++ b/src/entities/management/model/useTeamMutations.ts
@@ -8,10 +8,12 @@ import {
   ITeamTagInput,
   IUseTeamMutations,
 } from '@/entities/management/model/teamMutations.types.ts';
-import { TEAM_ID } from '@/entities/management/model/useTeamQueries.ts';
 import apiRequest from '@/shared/api/apiRequest.ts';
+import { useTeamStore } from '@/shared/model/store/teamStore.ts';
 
 export default function useTeamMutations() {
+  const teamId = useTeamStore((state) => state.teamId);
+
   // 팀 수정
   const useEditTeamMutation = () => {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
@@ -21,7 +23,7 @@ export default function useTeamMutations() {
         if (imageFile) formData.append('imageFile', imageFile);
 
         return await apiRequest({
-          url: `/api/v2/team/${TEAM_ID}`,
+          url: `/api/v2/team/${teamId}`,
           method: 'PATCH',
           data: formData,
           headers: { 'Content-Type': 'multipart/form-data' },
@@ -29,7 +31,7 @@ export default function useTeamMutations() {
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['management', 'team', TEAM_ID],
+          queryKey: ['management', 'team', teamId],
         });
       },
       onError: (err) => console.error(err),
@@ -42,14 +44,14 @@ export default function useTeamMutations() {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async ({ tagName }: { tagName: string }) => {
         return await apiRequest({
-          url: `/api/v2/tag/team/${TEAM_ID}`,
+          url: `/api/v2/tag/team/${teamId}`,
           method: 'POST',
           data: { tagName },
         });
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['management', 'team', 'tag', TEAM_ID],
+          queryKey: ['management', 'team', 'tag', teamId],
         });
       },
       onError: (err) => console.error(err),
@@ -62,13 +64,13 @@ export default function useTeamMutations() {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async (tagId: number) => {
         await apiRequest({
-          url: `/api/v2/tag/${tagId}/team/${TEAM_ID}`,
+          url: `/api/v2/tag/${tagId}/team/${teamId}`,
           method: 'DELETE',
         });
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['management', 'team', 'tag', TEAM_ID],
+          queryKey: ['management', 'team', 'tag', teamId],
         });
       },
     });
@@ -80,14 +82,14 @@ export default function useTeamMutations() {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async ({ tagId, tagName }: ITeamTagInput) => {
         await apiRequest({
-          url: `/api/v2/tag/${tagId}/team/${TEAM_ID}`,
+          url: `/api/v2/tag/${tagId}/team/${teamId}`,
           method: 'PATCH',
           data: { tagName },
         });
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['management', 'team', 'tag', TEAM_ID],
+          queryKey: ['management', 'team', 'tag', teamId],
         });
       },
     });
@@ -99,7 +101,7 @@ export default function useTeamMutations() {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async ({ memberId, tagName }: ICreateMemberTagInput) => {
         return await apiRequest({
-          url: `/api/v2/tag/team/${TEAM_ID}/member/${memberId}`,
+          url: `/api/v2/tag/team/${teamId}/member/${memberId}`,
           method: 'POST',
           data: { tagName },
         });
@@ -118,7 +120,7 @@ export default function useTeamMutations() {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async ({ tagId, memberId, tagName }: IEditMemberTagInput) => {
         return await apiRequest({
-          url: `/api/v2/tag/${tagId}/team/${TEAM_ID}/member/${memberId}`,
+          url: `/api/v2/tag/${tagId}/team/${teamId}/member/${memberId}`,
           method: 'PATCH',
           data: { tagName },
         });
@@ -137,7 +139,7 @@ export default function useTeamMutations() {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async ({ memberId, tagId }: IDeleteMemberTag) => {
         return await apiRequest({
-          url: `/api/v2/tag/${tagId}/team/${TEAM_ID}/member/${memberId}`,
+          url: `/api/v2/tag/${tagId}/team/${teamId}/member/${memberId}`,
           method: 'DELETE',
         });
       },
@@ -155,14 +157,14 @@ export default function useTeamMutations() {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async ({ times }: IRegisterScheduleInput) => {
         return await apiRequest({
-          url: `/api/v2/schedule/teams/${TEAM_ID}`,
+          url: `/api/v2/schedule/teams/${teamId}`,
           method: 'POST',
           data: { times },
         });
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['management', 'teamMember', 'schedule', TEAM_ID],
+          queryKey: ['management', 'teamMember', 'schedule', teamId],
         });
       },
     });

--- a/src/entities/management/model/useTeamQueries.ts
+++ b/src/entities/management/model/useTeamQueries.ts
@@ -1,10 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { IScheduleDto } from '@/entities/management/management.types.ts';
 import apiRequest from '@/shared/api/apiRequest.ts';
+import { useTeamStore } from '@/shared/model/store/teamStore.ts';
 import { ITeamMemberResponse } from '@/shared/types/member.types.ts';
 import { Team, TeamTag } from '@/shared/types/team.types.ts';
-
-export const TEAM_ID = 3;
 
 interface ITeamResponse {
   team: Team;
@@ -17,13 +16,15 @@ interface IScheduleResponse {
 }
 
 export default function useTeamQueries() {
+  const teamId = useTeamStore((state) => state.teamId);
+
   // 팀 정보 조회 (팀 아이디)
   const useTeamByIdQuery = () => {
     const { isPending, isError, isSuccess, data } = useQuery({
-      queryKey: ['management', 'team', TEAM_ID],
+      queryKey: ['management', 'team', teamId],
       queryFn: () =>
         apiRequest({
-          url: `/api/v2/team/${TEAM_ID}`,
+          url: `/api/v2/team/${teamId}`,
           method: 'GET',
         }),
       select: (res): ITeamResponse => res.result,
@@ -36,10 +37,10 @@ export default function useTeamQueries() {
   // 팀 스케줄 조회
   const useTeamScheduleQuery = () => {
     const { isPending, isError, isSuccess, data } = useQuery({
-      queryKey: ['management', 'schedule', TEAM_ID],
+      queryKey: ['management', 'schedule', teamId],
       queryFn: () =>
         apiRequest({
-          url: `/api/v2/schedule/teams/${TEAM_ID}`,
+          url: `/api/v2/schedule/teams/${teamId}`,
           method: 'GET',
         }),
       select: (res): IScheduleDto[] =>
@@ -52,10 +53,10 @@ export default function useTeamQueries() {
   // 개인 스케줄 조회
   const useMyScheduleQuery = () => {
     const { isPending, isError, isSuccess, data } = useQuery({
-      queryKey: ['management', 'mySchedule', TEAM_ID],
+      queryKey: ['management', 'mySchedule', teamId],
       queryFn: () =>
         apiRequest({
-          url: `/api/v2/schedule/teams/${TEAM_ID}/my-schedules`,
+          url: `/api/v2/schedule/teams/${teamId}/my-schedules`,
           method: 'GET',
         }),
       select: (res): IScheduleDto[] =>
@@ -71,12 +72,12 @@ export default function useTeamQueries() {
     const sortedIds = [...teamMemberIds].sort((a, b) => a - b);
 
     const { isPending, isError, isSuccess, data } = useQuery({
-      queryKey: ['management', 'partialSchedule', TEAM_ID, sortedIds],
+      queryKey: ['management', 'partialSchedule', teamId, sortedIds],
       queryFn: () => {
         const queryString = sortedIds
           .map((id) => `teamMemberId=${encodeURIComponent(id)}`)
           .join('&');
-        const url = `/api/v2/schedule/teams/${TEAM_ID}/partial?${queryString}`;
+        const url = `/api/v2/schedule/teams/${teamId}/partial?${queryString}`;
         return apiRequest({
           url,
           method: 'GET',
@@ -93,10 +94,10 @@ export default function useTeamQueries() {
   // 팀 멤버 조회
   const useTeamMemberQuery = () => {
     const { isPending, isError, isSuccess, data } = useQuery({
-      queryKey: ['management', 'member', TEAM_ID],
+      queryKey: ['management', 'member', teamId],
       queryFn: () =>
         apiRequest({
-          url: `/api/v2/team/${TEAM_ID}/member-list`,
+          url: `/api/v2/team/${teamId}/member-list`,
           method: 'GET',
         }),
       select: (res): ITeamMemberResponse => res.result,

--- a/src/entities/memo/model/useMemoMutations.ts
+++ b/src/entities/memo/model/useMemoMutations.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { queryClient } from '@/app/provider/queryClient';
 import apiRequest from '@/shared/api/apiRequest';
+import { useTeamStore } from '@/shared/model/store/teamStore.ts';
 
 interface IMemoInput {
   title: string;
@@ -21,16 +22,16 @@ interface IMemoFolderMoveInput {
   folderId: number;
 }
 
-const TEAM_ID = 3;
-
 export default function useMemoMutations() {
+  const teamId = useTeamStore((state) => state.teamId);
+
   // 메모 생성
   const useCreateMemoMutation = () => {
     const { mutate, data, isPending, isError, isSuccess } = useMutation({
       mutationFn: async (data: IMemoInput) => {
         const { title, content, tags, folderId } = data;
         await apiRequest({
-          url: `/api/v2/memo/folders/${folderId}/teams/${TEAM_ID}`,
+          url: `/api/v2/memo/folders/${folderId}/teams/${teamId}`,
           method: 'POST',
           data: {
             title,

--- a/src/entities/memo/model/useMemoQueries.ts
+++ b/src/entities/memo/model/useMemoQueries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { TEAM_ID } from '@/entities/management/model/useTeamQueries.ts';
 import apiRequest from '@/shared/api/apiRequest';
+import { useTeamStore } from '@/shared/model/store/teamStore.ts';
 import { MemoType, FolderType } from '@/shared/types/memo.types';
 
 interface IMemoResponse {
@@ -34,13 +34,15 @@ interface IFolderResponse {
 }
 
 export default function useMemoQueries() {
+  const teamId = useTeamStore((state) => state.teamId);
+
   // 루트 폴더 조회
   const useRootFolderQuery = () => {
     const { isPending, isError, isSuccess, data } = useQuery({
-      queryKey: ['rootFolder', TEAM_ID],
+      queryKey: ['rootFolder', teamId],
       queryFn: () =>
         apiRequest({
-          url: `/api/v2/folder/root/${TEAM_ID}`,
+          url: `/api/v2/folder/root/${teamId}`,
           method: 'GET',
         }),
       select: (res): IFolderDto => res.result.folderDto,
@@ -53,7 +55,7 @@ export default function useMemoQueries() {
   // 메모 전체 조회
   const useMemoListQuery = (folderId: number) => {
     const { isPending, isError, isSuccess, data } = useQuery({
-      queryKey: ['memo', folderId, TEAM_ID],
+      queryKey: ['memo', folderId, teamId],
       enabled: Number.isFinite(folderId),
       queryFn: () =>
         apiRequest({

--- a/src/pages/EndPage/end.tsx
+++ b/src/pages/EndPage/end.tsx
@@ -6,23 +6,27 @@ import { EndModal } from '@/entities/end/ui/EndModal.tsx';
 import { EndProject } from '@/entities/end/ui/EndProject.tsx';
 import useTeamQueries from '@/entities/management/model/useTeamQueries.ts';
 import Modal from '@/shared/components/modal/Modal.tsx';
+import { getMemberIdFromToken } from '@/shared/lib/utils/getMemberIdFromToken.ts';
 
 export function EndPage() {
   const [showModal, setShowModal] = useState(false);
   const navigate = useNavigate();
+  const memberId = getMemberIdFromToken();
 
-  // 팀 관리 PR 머지 후 API에서 teamName, isLeader 받아온 뒤 수정
-  const isLeader = true;
-
-  const { useTeamByIdQuery } = useTeamQueries();
+  const { useTeamByIdQuery, useTeamMemberQuery } = useTeamQueries();
   const { data: team, isPending: isTeamLoading } = useTeamByIdQuery();
+  const { data: members, isPending: isMembersLoading } = useTeamMemberQuery();
+
   const { useWithdrawTeamMutation, useCompleteTeamMutation } =
     useEndMutations();
   const { mutate: withdrawTeam } = useWithdrawTeamMutation();
   const { mutate: completeTeam } = useCompleteTeamMutation();
 
-  if (isTeamLoading || !team) return <div>로딩중..</div>;
+  if (isTeamLoading || isMembersLoading || !team || !members)
+    return <div>로딩중..</div>;
   const teamName = team?.team?.title ?? '';
+  const leaderId = members?.leader.member.id;
+  const isLeader = memberId === leaderId;
 
   const handleOpenModal = () => setShowModal(true);
   const handleCloseModal = () => setShowModal(false);

--- a/src/pages/EndPage/end.tsx
+++ b/src/pages/EndPage/end.tsx
@@ -4,6 +4,7 @@ import useEndMutations from '@/entities/end/model/useEndMutations.ts';
 import { EndMember } from '@/entities/end/ui/EndMember.tsx';
 import { EndModal } from '@/entities/end/ui/EndModal.tsx';
 import { EndProject } from '@/entities/end/ui/EndProject.tsx';
+import useTeamQueries from '@/entities/management/model/useTeamQueries.ts';
 import Modal from '@/shared/components/modal/Modal.tsx';
 
 export function EndPage() {
@@ -11,13 +12,17 @@ export function EndPage() {
   const navigate = useNavigate();
 
   // 팀 관리 PR 머지 후 API에서 teamName, isLeader 받아온 뒤 수정
-  const teamName = '팀 매니저';
   const isLeader = true;
 
+  const { useTeamByIdQuery } = useTeamQueries();
+  const { data: team, isPending: isTeamLoading } = useTeamByIdQuery();
   const { useWithdrawTeamMutation, useCompleteTeamMutation } =
     useEndMutations();
   const { mutate: withdrawTeam } = useWithdrawTeamMutation();
   const { mutate: completeTeam } = useCompleteTeamMutation();
+
+  if (isTeamLoading || !team) return <div>로딩중..</div>;
+  const teamName = team?.team?.title ?? '';
 
   const handleOpenModal = () => setShowModal(true);
   const handleCloseModal = () => setShowModal(false);

--- a/src/shared/lib/utils/getMemberIdFromToken.ts
+++ b/src/shared/lib/utils/getMemberIdFromToken.ts
@@ -1,0 +1,13 @@
+export function getMemberIdFromToken() {
+  try {
+    const token = localStorage.getItem('accessToken');
+    if (!token) return null;
+
+    const base64Payload = token.split('.')[1];
+    const payload = JSON.parse(atob(base64Payload));
+    return Number(payload.sub);
+  } catch (e) {
+    console.error('jwt 디코드 실패', e);
+    return null;
+  }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Jira 이슈 번호

- TM-148

## 📝 작업 내용

> 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능)

- 주요 변경사항
  - 팀 아이디 Zustand store에서 동적으로 받아와서 사용하도록 수정
  - 팀명 동적으로 받아오도록 수정
  - JWT 토큰의 payload에서 멤버 아이디 추출하여 리더인지 비교하여 페이지 조건부 렌더링
