### PR TITLE
[TM-164] 팀 변경 시 이전 데이터 캐시되는 버그 수정

### DIFF
--- a/src/entities/notice/model/useNoticeQueries.ts
+++ b/src/entities/notice/model/useNoticeQueries.ts
@@ -11,7 +11,7 @@ export default function useNoticeQueries() {
   // 최신 공지 조회
   const useRecentNoticeQuery = () => {
     const queryResult = useQuery({
-      queryKey: ['notice', 'recent'],
+      queryKey: ['notices', 'recent', teamId],
       queryFn: async () => {
         return await apiRequest({
           url: `/api/v2/team/${teamId}/notice`,
@@ -33,7 +33,7 @@ export default function useNoticeQueries() {
       Error,
       NoticeResponse[]
     >({
-      queryKey: ['notice'],
+      queryKey: ['notices', teamId],
       queryFn: async () => {
         return await apiRequest({
           url: `/api/v2/team/${teamId}/notice/list`,
@@ -60,7 +60,7 @@ export default function useNoticeQueries() {
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['notice'],
+          queryKey: ['notices'],
         });
       },
     });

--- a/src/entities/notice/model/useNoticeQueries.ts
+++ b/src/entities/notice/model/useNoticeQueries.ts
@@ -11,7 +11,7 @@ export default function useNoticeQueries() {
   // 최신 공지 조회
   const useRecentNoticeQuery = () => {
     const queryResult = useQuery({
-      queryKey: ['notices', 'recent', teamId],
+      queryKey: ['notice', teamId, 'recent'],
       queryFn: async () => {
         return await apiRequest({
           url: `/api/v2/team/${teamId}/notice`,
@@ -33,7 +33,7 @@ export default function useNoticeQueries() {
       Error,
       NoticeResponse[]
     >({
-      queryKey: ['notices', teamId],
+      queryKey: ['notice', teamId, 'list'],
       queryFn: async () => {
         return await apiRequest({
           url: `/api/v2/team/${teamId}/notice/list`,
@@ -60,7 +60,7 @@ export default function useNoticeQueries() {
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['notices'],
+          queryKey: ['notice', teamId],
         });
       },
     });

--- a/src/entities/resource/model/useResourceQueries.ts
+++ b/src/entities/resource/model/useResourceQueries.ts
@@ -16,7 +16,7 @@ export const useGetResourceList = () => {
     Error,
     Resource[]
   >({
-    queryKey: ['resource', 'list'],
+    queryKey: ['resource', 'list', teamId],
     queryFn: async () => {
       return await apiRequest({
         url: `/api/v2/data/${teamId}`,

--- a/src/entities/user/model/useProfileQueries.ts
+++ b/src/entities/user/model/useProfileQueries.ts
@@ -1,12 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { User } from '@/entities/user/user.types';
 import apiRequest from '@/shared/api/apiRequest';
+import { useTeamStore } from '@/shared/model/store/teamStore';
 import { APIResponse } from '@/shared/types/api.types';
 
 // 프로필 조회
 export const useGetProfile = () => {
+  const teamId = useTeamStore((state) => state.teamId);
+
   return useQuery<APIResponse<User>, Error, User>({
-    queryKey: ['user', 'profile'],
+    queryKey: ['user', 'profile', teamId],
     queryFn: async () => {
       return await apiRequest({
         url: '/api/v2/member',

--- a/src/features/calendar/model/useEventQueries.ts
+++ b/src/features/calendar/model/useEventQueries.ts
@@ -17,7 +17,7 @@ export default function useEventQueries(yearMonth?: string) {
     data: FetchEventResponse[];
   } => {
     const { isPending, isError, error, isSuccess, data } = useQuery({
-      queryKey: ['event', 'upcoming'],
+      queryKey: ['event', 'upcoming', teamId],
       queryFn: async () => {
         return await apiRequest({
           url: `/api/v2/calendar/upcoming?teamId=${teamId}`,


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Jira 이슈 번호

- TM-164

## 📝 작업 내용

> 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능)

- 구현 기능 요약

팀 변경 시 이전 팀의 데이터가 캐시에 남아있는 현상 방지하기 위해 teamId를 쿼리 키에 추가 
-> 추후 `query key factory pattern`으로 도메인 별 쿼리 키 구조 개선 필요

추가한 도메인: 공지, 자료, 프로필, 다가오는 일정