### PR TITLE
[TM-168] 다가오는 일정 컴포넌트 확장성있게 개선 

### DIFF
--- a/src/app/routes/paths.ts
+++ b/src/app/routes/paths.ts
@@ -89,11 +89,20 @@ interface RouteConfig {
   label: string; // 네비게이션 링크에 표시될 텍스트
   to: AppPath | ((teamId: number) => string); // 경로
   component?: React.ComponentType; // 해당 경로에 렌더링될 컴포넌트
+  props?: Record<string, unknown>;
   icon?: React.ComponentType; // 메뉴에서 렌더링 될 아이콘
 }
 
 export const mainRoutes: RouteConfig[] = [
-  { label: '다가오는 일정', to: PATHS.CALENDAR, component: UpcomingEventList },
+  {
+    label: '다가오는 일정',
+    to: PATHS.CALENDAR,
+    component: UpcomingEventList,
+    props: {
+      limit: 3,
+      variant: 'card',
+    },
+  },
   { label: '투두리스트', to: PATHS.TODO_LIST, component: MyTodoList },
   {
     label: '최근 업데이트 된 자료',

--- a/src/pages/CalendarPage/calendar.tsx
+++ b/src/pages/CalendarPage/calendar.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 import { usePopoverRender } from '@/features/calendar/lib';
 import { useCalendarStore } from '@/features/calendar/model';
-import { EventEditorModal } from '@/features/calendar/ui';
 import useEventQueries from '@/features/calendar/model/useEventQueries';
+import { EventEditorModal } from '@/features/calendar/ui';
+import { useCalendarViewModel } from '@/widgets/calendar/model/useCalendarViewModel';
 import EventCalendar from '@/widgets/calendar/ui/EventCalendar';
 import { UpcomingEventList } from '@/widgets/upcoming-event';
-import { useCalendarViewModel } from '@/widgets/calendar/model/useCalendarViewModel';
 
 export function CalendarPage() {
   const selectedDate = useCalendarStore((state) => state.selectedDate);
@@ -29,7 +29,7 @@ export function CalendarPage() {
         {/* 다가오는 일정 */}
         <UpcomingSchedulesWrapper>
           <UpcomingScheduleTitle>다가오는 일정</UpcomingScheduleTitle>
-          <UpcomingEventList />
+          <UpcomingEventList limit={5} variant="list" />
         </UpcomingSchedulesWrapper>
       </Container>
 
@@ -51,6 +51,7 @@ const UpcomingSchedulesWrapper = styled.div`
   flex-direction: column;
   gap: 16px;
   width: 436px;
+  height: 520px;
 `;
 
 const UpcomingScheduleTitle = styled.h2`

--- a/src/pages/MainPage/main.tsx
+++ b/src/pages/MainPage/main.tsx
@@ -28,7 +28,7 @@ export function MainPage() {
                 navLink={
                   <MainSectionLink to={item.to}>{item.label}</MainSectionLink>
                 }
-                content={<ContentComponent />}
+                content={<ContentComponent {...(item.props || {})} />}
               />
             </SectionWrapper>
           );

--- a/src/widgets/upcoming-event/UpcomingEventList.tsx
+++ b/src/widgets/upcoming-event/UpcomingEventList.tsx
@@ -4,7 +4,15 @@ import FallbackCard from '@/entities/main/ui/FallbackCard';
 import useEventQueries from '@/features/calendar/model/useEventQueries';
 import Skeleton from '@/shared/components/skeleton/Skeleton';
 
-function UpcomingEventList() {
+interface UpcomingEventListProps {
+  limit?: 3 | 5; // 표시할 최대 일정 수: 메인 위젯(3), 캘린더 페이지(5)
+  variant?: 'card' | 'list'; // 스켈레톤 variant: card: 카드형 / list: 리스트형
+}
+
+function UpcomingEventList({
+  limit = 3,
+  variant = 'card',
+}: UpcomingEventListProps) {
   const { useUpcomingEventQuery } = useEventQueries();
   const {
     isPending,
@@ -13,26 +21,50 @@ function UpcomingEventList() {
     data: eventList,
   } = useUpcomingEventQuery();
 
-  if (isPending) return <Skeleton width="518px" height="222px" />;
-  if (isError) return <FallbackCard>일정을 불러올 수 없습니다.</FallbackCard>;
-  if (isSuccess && eventList.length === 0)
-    return <FallbackCard>아직 생성된 일정이 없습니다.</FallbackCard>;
+  if (isPending) {
+    if (variant === 'card') return <Skeleton width="518px" height="222px" />;
+    return (
+      <EventListWrapper>
+        {Array.from({ length: limit }).map((_, idx) => (
+          <Skeleton
+            key={`upcoming-event-skeleton-${idx}`}
+            width="100%"
+            height="66px"
+          />
+        ))}
+      </EventListWrapper>
+    );
+  }
+
+  const isEmpty = isSuccess && eventList.length === 0;
+
+  if (isError || isEmpty) {
+    const message = isError
+      ? '일정을 불러올 수 없습니다.'
+      : '아직 생성된 일정이 없습니다.';
+
+    if (variant === 'card') return <FallbackCard>{message}</FallbackCard>;
+
+    return (
+      <Container>
+        <CalendarFallback>{message}</CalendarFallback>
+      </Container>
+    );
+  }
 
   return (
     <Container>
       <EventListWrapper>
         {isSuccess &&
-          eventList.map((event, idx) => (
-            <UpcomingSchedule
-              event={event.planDto}
-              key={`upcoming-schedule-${idx}`}
-            />
-          ))}
+          eventList
+            .slice(0, limit)
+            .map((event, idx) => (
+              <UpcomingSchedule
+                event={event.planDto}
+                key={`upcoming-schedule-${idx}`}
+              />
+            ))}
       </EventListWrapper>
-
-      {isSuccess && eventList.length === 0 && (
-        <EmptySchedule>아직 생성된 일정이 없습니다.</EmptySchedule>
-      )}
     </Container>
   );
 }
@@ -46,6 +78,7 @@ const Container = styled.section`
   align-items: flex-start;
   gap: 16px;
   width: 100%;
+  height: 100%;
 `;
 
 const EventListWrapper = styled.ul`
@@ -53,16 +86,17 @@ const EventListWrapper = styled.ul`
   flex-direction: column;
   gap: 12px;
   width: 100%;
-  height: 222px;
+  max-height: 378px;
   overflow-y: auto;
 `;
 
-const EmptySchedule = styled.p`
+const CalendarFallback = styled.p`
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   font-size: 18px;
   font-weight: 500;
+  text-align: center;
   color: ${({ theme }) => theme.colors.black};
 `;

--- a/src/widgets/upcoming-event/UpcomingEventList.tsx
+++ b/src/widgets/upcoming-event/UpcomingEventList.tsx
@@ -5,8 +5,8 @@ import useEventQueries from '@/features/calendar/model/useEventQueries';
 import Skeleton from '@/shared/components/skeleton/Skeleton';
 
 interface UpcomingEventListProps {
-  limit?: 3 | 5; // 표시할 최대 일정 수: 메인 위젯(3), 캘린더 페이지(5)
-  variant?: 'card' | 'list'; // 스켈레톤 variant: card: 카드형 / list: 리스트형
+  limit?: 3 | 5; // 표시할 최대 일정 수: 메인(3), 캘린더(5)
+  variant?: 'card' | 'list'; // 렌더링 스타일: card: 카드형 (메인) / list: 리스트형 (캘린더)
 }
 
 function UpcomingEventList({


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Jira 이슈 번호

- TM-168

## 📝 작업 내용

> 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능)

- 구현 기능 요약
  - `UpcomingEventList` limit, varaiant prop을 활용하여 메인/캘린더 페이지에서 공용 위젯으로 사용
  - mainRoutes props 속성 추가